### PR TITLE
Some more fixes to the monitor conversion.

### DIFF
--- a/mozilla_l10n/convert_from_github/monitor_branchmap
+++ b/mozilla_l10n/convert_from_github/monitor_branchmap
@@ -1,0 +1,1 @@
+l10n default


### PR DESCRIPTION
Only convert the l10n branch, do locale code mappings.
There's no way to not create the branch bookmarks, it seems. Might
still run a command to prune those that got created.